### PR TITLE
[React Package] - Naming convention of React SVG components

### DIFF
--- a/interface/index.ts
+++ b/interface/index.ts
@@ -12,3 +12,8 @@ export interface TemplateProps {
     fileName: string;
     data: string;
 }
+
+export interface NameProps {
+    iconName: string;
+    type: string;
+}

--- a/scripts/iconScript.ts
+++ b/scripts/iconScript.ts
@@ -4,11 +4,12 @@ import * as fs from 'fs'
 import { IconGenerateScript } from '../interface/index'
 import componentTemplate from '../template/iconComponent'
 import iconIndexTemplate from '../template/iconIndex'
+import { nameFunction } from '../utils/nameFunction'
 
 async function generateIconComponents ({ type, from }: IconGenerateScript) {
   const iconNames = await fs.promises.readdir(from)
   for (const iconName of iconNames) {
-    const fileName = iconName.slice(0, iconName.length - 4).toUpperCase().concat(`_${type.toUpperCase()}`)
+    const fileName = nameFunction({ iconName, type })
     // fetching Data of the required SVG file
     fs.readFile(path.resolve(__dirname, `../svg/${type}/${iconName}`), 'utf8', async function (err, data) {
       if (err) {

--- a/scripts/iconScript.ts
+++ b/scripts/iconScript.ts
@@ -8,8 +8,7 @@ import iconIndexTemplate from '../template/iconIndex'
 async function generateIconComponents ({ type, from }: IconGenerateScript) {
   const iconNames = await fs.promises.readdir(from)
   for (const iconName of iconNames) {
-    const fileName = iconName.slice(0, iconName.length - 4).concat(type.charAt(0).toUpperCase() + type.slice(1))
-
+    const fileName = iconName.slice(0, iconName.length - 4).toUpperCase().concat(`_${type.toUpperCase()}`)
     // fetching Data of the required SVG file
     fs.readFile(path.resolve(__dirname, `../svg/${type}/${iconName}`), 'utf8', async function (err, data) {
       if (err) {
@@ -18,7 +17,7 @@ async function generateIconComponents ({ type, from }: IconGenerateScript) {
 
       if (type === 'animated') {
         data = data.replace('xml:space="preserve"', '')
-        if (fileName === 'installingAnimated') {
+        if (fileName === 'INSTALLING_ANIMATED') {
           while (data.includes('class="st0"')) {
             data = data.replace('class="st0"', 'className="st0"')
           }

--- a/template/iconComponent.ts
+++ b/template/iconComponent.ts
@@ -8,7 +8,7 @@ import * as React from 'react';
 import { IconProps, valuesMap } from '../helper';
 import { flipFunction } from '../flipFunction';
 
-function Eos${fileName}({size = "m", color = "black", rotate = 0, horizontalFlip = false, verticalFlip = false}: IconProps) {
+function EOS_${fileName}({size = "m", color = "black", rotate = 0, horizontalFlip = false, verticalFlip = false}: IconProps) {
     const sizeString: string = size.toString()
     if(Object.keys(valuesMap).includes(sizeString)) {
         size = valuesMap[size]
@@ -19,7 +19,7 @@ return (
     );
 };
 
-export default Eos${fileName};
+export default EOS_${fileName};
 `
   return (render)
 }

--- a/template/iconIndex.ts
+++ b/template/iconIndex.ts
@@ -3,7 +3,7 @@ interface TemplateProps {
 }
 
 function iconIndexTemplate ({ fileName }:TemplateProps) {
-  const indexContent = `export { default as Eos${fileName} } from './${fileName}';
+  const indexContent = `export { default as EOS_${fileName} } from './${fileName}';
 `
   return (indexContent)
 }

--- a/test/animatedSvg.test.js
+++ b/test/animatedSvg.test.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-undef */
 import React from 'react'
 // import renderer from 'react-test-renderer'
-import { EosloadingAnimated } from '../lib'
+import { EOS_LOADING_ANIMATED } from '../lib'
 import { render, cleanup } from '@testing-library/react'
 import '@testing-library/jest-dom/extend-expect'
 
@@ -10,7 +10,7 @@ afterEach(cleanup)
 it('Animated SVG Size prop test', () => {
   const randomSize = Math.floor(Math.random()) + 1
   const { getByTestId } = render(
-    <EosloadingAnimated size={`${randomSize}`}/>
+    <EOS_LOADING_ANIMATED size={`${randomSize}`}/>
   )
   expect(getByTestId('eos-svg-component')).toHaveStyle({
     width: `${randomSize}`,
@@ -20,7 +20,7 @@ it('Animated SVG Size prop test', () => {
 
 it('Animated SVG Color prop test', () => {
   const { getByTestId } = render(
-    <EosloadingAnimated color="blue"/>
+    <EOS_LOADING_ANIMATED color="blue"/>
   )
   expect(getByTestId('eos-svg-component')).toHaveAttribute('fill', 'blue')
 })
@@ -28,21 +28,21 @@ it('Animated SVG Color prop test', () => {
 it('Animated SVG Rotation prop test', () => {
   const randomDegree = Math.floor(Math.random() * 360) + 1
   const { getByTestId } = render(
-    <EosloadingAnimated rotate={`${randomDegree}`}/>
+    <EOS_LOADING_ANIMATED rotate={`${randomDegree}`}/>
   )
   expect(getByTestId('eos-svg-component')).toHaveAttribute('transform', `rotate(${randomDegree}) translate(0, 0) scale(1, 1)`)
 })
 
 it('Animated SVG horizontalFlip prop test', () => {
   const { getByTestId } = render(
-    <EosloadingAnimated horizontalFlip={true}/>
+    <EOS_LOADING_ANIMATED horizontalFlip={true}/>
   )
   expect(getByTestId('eos-svg-component')).toHaveAttribute('transform', 'rotate(0) translate(24, 0) scale(-1, 1)')
 })
 
 it('Animated SVG verticalFlip prop test', () => {
   const { getByTestId } = render(
-    <EosloadingAnimated verticalFlip={true}/>
+    <EOS_LOADING_ANIMATED verticalFlip={true}/>
   )
   expect(getByTestId('eos-svg-component')).toHaveAttribute('transform', 'rotate(0) translate(0, 24) scale(1, -1)')
 })

--- a/test/filledsvg.test.js
+++ b/test/filledsvg.test.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-undef */
 import React from 'react'
 // import renderer from 'react-test-renderer'
-import { Eos10kFilled } from '../lib'
+import { EOS_10K_FILLED } from '../lib'
 import { render, cleanup } from '@testing-library/react'
 import '@testing-library/jest-dom/extend-expect'
 
@@ -10,7 +10,7 @@ afterEach(cleanup)
 it('Filled SVG Size prop test', () => {
   const randomSize = Math.floor(Math.random()) + 1
   const { getByTestId } = render(
-    <Eos10kFilled size={`${randomSize}`}/>
+    <EOS_10K_FILLED size={`${randomSize}`}/>
   )
   expect(getByTestId('eos-svg-component')).toHaveStyle({
     width: `${randomSize}`,
@@ -20,7 +20,7 @@ it('Filled SVG Size prop test', () => {
 
 it('Filled SVG Color prop test', () => {
   const { getByTestId } = render(
-    <Eos10kFilled color="blue"/>
+    <EOS_10K_FILLED color="blue"/>
   )
   expect(getByTestId('eos-svg-component')).toHaveAttribute('fill', 'blue')
 })
@@ -28,21 +28,21 @@ it('Filled SVG Color prop test', () => {
 it('Filled SVG Rotation prop test', () => {
   const randomDegree = Math.floor(Math.random() * 360) + 1
   const { getByTestId } = render(
-    <Eos10kFilled rotate={`${randomDegree}`}/>
+    <EOS_10K_FILLED rotate={`${randomDegree}`}/>
   )
   expect(getByTestId('eos-svg-component')).toHaveAttribute('transform', `rotate(${randomDegree}) translate(0, 0) scale(1, 1)`)
 })
 
 it('Filled SVG horizontalFlip prop test', () => {
   const { getByTestId } = render(
-    <Eos10kFilled horizontalFlip={true}/>
+    <EOS_10K_FILLED horizontalFlip={true}/>
   )
   expect(getByTestId('eos-svg-component')).toHaveAttribute('transform', 'rotate(0) translate(24, 0) scale(-1, 1)')
 })
 
 it('Filled SVG verticalFlip prop test', () => {
   const { getByTestId } = render(
-    <Eos10kFilled verticalFlip={true}/>
+    <EOS_10K_FILLED verticalFlip={true}/>
   )
   expect(getByTestId('eos-svg-component')).toHaveAttribute('transform', 'rotate(0) translate(0, 24) scale(1, -1)')
 })

--- a/test/outlinedSvg.test.js
+++ b/test/outlinedSvg.test.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-undef */
 import React from 'react'
 // import renderer from 'react-test-renderer'
-import { Eos10kOutlined } from '../lib'
+import { EOS_10K_OUTLINED } from '../lib'
 import { render, cleanup } from '@testing-library/react'
 import '@testing-library/jest-dom/extend-expect'
 
@@ -10,7 +10,7 @@ afterEach(cleanup)
 it('Outlined SVG Size prop test', () => {
   const randomSize = Math.floor(Math.random()) + 1
   const { getByTestId } = render(
-    <Eos10kOutlined size={`${randomSize}`}/>
+    <EOS_10K_OUTLINED size={`${randomSize}`}/>
   )
   expect(getByTestId('eos-svg-component')).toHaveStyle({
     width: `${randomSize}`,
@@ -20,7 +20,7 @@ it('Outlined SVG Size prop test', () => {
 
 it('Outlined SVG Color prop test', () => {
   const { getByTestId } = render(
-    <Eos10kOutlined color="blue"/>
+    <EOS_10K_OUTLINED color="blue"/>
   )
   expect(getByTestId('eos-svg-component')).toHaveAttribute('fill', 'blue')
 })
@@ -28,21 +28,21 @@ it('Outlined SVG Color prop test', () => {
 it('Outlined SVG Rotation prop test', () => {
   const randomDegree = Math.floor(Math.random() * 360) + 1
   const { getByTestId } = render(
-    <Eos10kOutlined rotate={`${randomDegree}`}/>
+    <EOS_10K_OUTLINED rotate={`${randomDegree}`}/>
   )
   expect(getByTestId('eos-svg-component')).toHaveAttribute('transform', `rotate(${randomDegree}) translate(0, 0) scale(1, 1)`)
 })
 
 it('Outlined SVG horizontalFlip prop test', () => {
   const { getByTestId } = render(
-    <Eos10kOutlined horizontalFlip={true}/>
+    <EOS_10K_OUTLINED horizontalFlip={true}/>
   )
   expect(getByTestId('eos-svg-component')).toHaveAttribute('transform', 'rotate(0) translate(24, 0) scale(-1, 1)')
 })
 
 it('Outlined SVG verticalFlip prop test', () => {
   const { getByTestId } = render(
-    <Eos10kOutlined verticalFlip={true}/>
+    <EOS_10K_OUTLINED verticalFlip={true}/>
   )
   expect(getByTestId('eos-svg-component')).toHaveAttribute('transform', 'rotate(0) translate(0, 24) scale(1, -1)')
 })

--- a/utils/nameFunction.ts
+++ b/utils/nameFunction.ts
@@ -1,0 +1,13 @@
+import { NameProps } from '../interface/index'
+
+export function nameFunction ({ iconName, type }: NameProps) {
+  // SCREAMING_SNAKE_CASE naming convention
+  // EOS_NAME_THEME
+  const NAME = iconName.slice(0, iconName.length - 4).toUpperCase()
+  const THEME = `_${type.toUpperCase()}`
+
+  // NAME_THEME
+  const fileName = NAME.concat(THEME)
+
+  return fileName
+}


### PR DESCRIPTION
- changed the previously used naming convention `EosnameTheme` to `EOS_NAME_THEME`
- Updated the tests to use the latest icon names